### PR TITLE
feat: request user field

### DIFF
--- a/client/src/components/InlineSearch.js
+++ b/client/src/components/InlineSearch.js
@@ -142,7 +142,7 @@ const resultsBoxVisualProps = {
   style: {
     position: 'absolute',
     left: 0,
-    zIndex: 1,
+    zIndex: 100,
     maxHeight: 5.5 * itemHeight + 'em',
     overflowX: 'hidden',
     overflowY: 'scroll',

--- a/client/src/components/RequestForm.js
+++ b/client/src/components/RequestForm.js
@@ -26,6 +26,7 @@ import BuildingAutocomplete from './BuildingAutocomplete'
 import RoomAutocomplete from './RoomAutocomplete'
 import ModelAutocomplete from './ModelAutocomplete'
 import SupplierAutocomplete from './SupplierAutocomplete'
+import UserAutocomplete from './UserAutocomplete'
 
 const tmpUppercasey = v => (f.isString(v) ? v.toUpperCase() : v)
 
@@ -354,6 +355,17 @@ class RequestForm extends React.Component {
                   <FormGroup label={t('request_form_field.attachments')}>
                     <InputFileUpload {...formPropsFor('attachments')} />
                   </FormGroup>
+
+                  <RequestInput field={formPropsFor('user')}>
+                    {userField =>
+                      // NOTE: don't show at all if not writable
+                      !userField.readOnly && (
+                        <FormGroup label={userField.label}>
+                          <UserAutocomplete onlyRequesters {...userField} />
+                        </FormGroup>
+                      )
+                    }
+                  </RequestInput>
 
                   <Let accTypeField={formPropsFor('accounting_type')}>
                     {({ accTypeField }) =>

--- a/client/src/components/UserAutocomplete.js
+++ b/client/src/components/UserAutocomplete.js
@@ -5,12 +5,17 @@ import { DisplayName } from './decorators'
 import InlineSearch from './InlineSearch'
 
 const SEARCH_USERS_QUERY = gql`
-  query searchUsers($searchTerm: String! = "", $excludeIds: [ID]) {
+  query searchUsers(
+    $searchTerm: String! = ""
+    $excludeIds: [ID]
+    $isRequester: Boolean
+  ) {
     users(
       search_term: $searchTerm
       limit: 25
       offset: 0
       exclude_ids: $excludeIds
+      isRequester: $isRequester
     ) {
       id
       firstname
@@ -19,10 +24,15 @@ const SEARCH_USERS_QUERY = gql`
   }
 `
 
-const UserAutocomplete = ({ onSelect, excludeIds, ...props }) => (
+const UserAutocomplete = ({
+  onSelect,
+  excludeIds,
+  onlyRequesters,
+  ...props
+}) => (
   <InlineSearch
     searchQuery={SEARCH_USERS_QUERY}
-    queryVariables={{ excludeIds }}
+    queryVariables={{ excludeIds, isRequester: onlyRequesters }}
     itemToString={DisplayName}
     onSelect={onSelect}
     {...props}

--- a/client/src/containers/RequestEdit.js
+++ b/client/src/containers/RequestEdit.js
@@ -188,6 +188,7 @@ export const requestDataFromFields = (request, fields) => {
   const boolify = (val, name) => f.presence(val) && name === val
 
   const model = valueIfWritable(fields, request, 'model')
+  const user = valueIfWritable(fields, request, 'user')
   const supplier = valueIfWritable(fields, request, 'supplier')
   const room = valueIfWritable(fields, request, 'room')
 
@@ -207,6 +208,8 @@ export const requestDataFromFields = (request, fields) => {
 
     ...fieldIfWritable(fields, request, 'accounting_type'),
     ...fieldIfWritable(fields, request, 'internal_order_number'),
+
+    ...(user ? { user: user.id } : null),
 
     replacement: boolify(
       valueIfWritable(fields, request, 'replacement'),

--- a/client/src/graphql-fragments.js
+++ b/client/src/graphql-fragments.js
@@ -102,6 +102,17 @@ export const RequestFieldsForEdit = gql`
       }
     }
 
+    user {
+      read
+      write
+      required
+      value {
+        id
+        firstname
+        lastname
+      }
+    }
+
     category {
       read
       write

--- a/client/src/locale/translations.json
+++ b/client/src/locale/translations.json
@@ -38,6 +38,7 @@
     "building": "Gebäude",
     "room": "Raum",
     "motivation": "Begründung",
+    "user": "Antragssteller",
 
     "replacement": "Ersatz / Neu",
     "request_replacement_labels_new": "Neu",

--- a/server/resources/all/schema.edn
+++ b/server/resources/all/schema.edn
@@ -359,7 +359,7 @@
                               :required {:type (non-null Boolean)},
                               :value {:resolve :template, :type :Template},
                               :write {:type (non-null Boolean)}}},
-    :RequestFieldUser {:fields {:default {:resolve :user, :type :User},
+    :RequestFieldUser {:fields {:default {:type ID},
                                 :read {:type (non-null Boolean)},
                                 :required {:type (non-null Boolean)},
                                 :value {:resolve :user, :type :User},

--- a/server/resources/all/schema.edn
+++ b/server/resources/all/schema.edn
@@ -464,8 +464,9 @@
                 :type (list :Supplier)},
     :templates {:resolve :templates, :type (list :Template)},
     :users {:args {:exclude_ids {:type (list ID)},
-                   :limit {:type (non-null Int)},
-                   :offset {:type (non-null Int)},
-                   :search_term {:type (non-null String)}},
+                   :isRequester {:type Boolean},
+                   :limit {:type Int},
+                   :offset {:type Int},
+                   :search_term {:type String}},
             :resolve :users,
             :type (list :User)}}}

--- a/server/spec/graphql/request/request_create_spec.rb
+++ b/server/spec/graphql/request/request_create_spec.rb
@@ -73,6 +73,9 @@ describe 'request' do
             supplier_name {
               ...RequestFieldString
             }
+            user {
+              ...RequestFieldUser
+            }
           }
         }
 
@@ -84,6 +87,12 @@ describe 'request' do
           required
           value { ...RoomProps }
           default { ...RoomProps}
+        }
+        fragment RequestFieldUser on RequestFieldUser {
+          read
+          write
+          value { id }
+          default
         }
         fragment RequestFieldPriority on RequestFieldPriority { value, read, write }
         fragment RequestFieldInspectorPriority on RequestFieldInspectorPriority { value, read, write }
@@ -134,7 +143,9 @@ describe 'request' do
                      general: true
                    },
                  },
-                 supplier_name: { value: nil, read: true, write: true })
+                 supplier_name: { value: nil, read: true, write: true },
+                 user: { value: nil, read: false, write: false, default: requester.id }
+                )
       end
 
       example 'from template' do
@@ -176,7 +187,9 @@ describe 'request' do
                      general: true
                    },
                  },
-                 supplier_name: { value: nil, read: true, write: false })
+                 supplier_name: { value: nil, read: true, write: false },
+                 user: { value: nil, read: false, write: false, default: requester.id }
+                )
       end
     end
   end

--- a/server/spec/graphql/users_spec.rb
+++ b/server/spec/graphql/users_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require_relative 'graphql_helper'
+
+describe 'users' do
+  context 'filter' do
+    it 'requesters only' do
+      user1 = FactoryBot.create(:user)
+      user2 = FactoryBot.create(:user)
+      FactoryBot.create(:requester_organization,
+                        user_id: user2.id)
+
+      admin = FactoryBot.create(:user)
+      FactoryBot.create(:admin, user_id: admin.id)
+
+      q = <<-GRAPHQL
+        query {
+          users(isRequester: true) {
+            id
+          }
+        }
+      GRAPHQL
+
+      result = query(q, admin.id)
+      expect(result).to eq({
+        'data' => {
+          'users' => [
+            { 'id' => user2.id }
+          ]
+        }
+      })
+    end
+  end
+end

--- a/server/src/all/leihs/procurement/permissions/request_fields.clj
+++ b/server/src/all/leihs/procurement/permissions/request_fields.clj
@@ -298,9 +298,11 @@
                 :write (not request-exists),
                 :default (:id template),
                 :required true},
-     :user {:read true,
-            :write (and (not request-exists) ; can be set only for new requests
-                        (or auth-user-is-requester
-                            auth-user-is-inspector
+     :user {:read (or category-viewable-by-auth-user
+                      auth-user-is-inspector
+                      auth-user-is-admin),
+            :write (and (not budget-period-is-past)
+                        (or category-inspectable-by-auth-user
                             auth-user-is-admin)),
-            :required true}}))
+            :required true,
+            :default (:user_id auth-entity)}}))

--- a/server/src/all/leihs/procurement/resources/request.clj
+++ b/server/src/all/leihs/procurement/resources/request.clj
@@ -362,7 +362,7 @@
         :if-only
         #(request-perms/authorized-to-write-all-fields? tx
                                                         auth-entity
-                                                        write-data))
+                                                        input-data))
       (as-> (var-get req-id) <>
         (get-request-by-id tx auth-entity <>)
         (reverse-exchange-attrs <>)

--- a/server/src/all/leihs/procurement/resources/users.clj
+++ b/server/src/all/leihs/procurement/resources/users.clj
@@ -17,11 +17,16 @@
           term-parts (and search-term
                           (map (fn [part] (str "%" part "%"))
                             (clj-str/split search-term #"\s+")))
+          is-requester (:isRequester args)
           exclude-ids (:exclude_ids args)
           offset (:offset args)
           limit (:limit args)]
       (sql/format
         (cond-> users-base-query
+          is-requester (sql/merge-join
+                         :procurement_requesters_organizations
+                         [:= :procurement_requesters_organizations.user_id
+                          :users.id])
           term-parts (sql/merge-where
                        (into [:and]
                              (map (fn [term-percent]


### PR DESCRIPTION
@nimaai 

- [x] TODO: fix permissions from backend/make some specs
  * only writable if user has right to select *different* user, default is current user
  * has write rights when request is for category where user is inspector (or always for admins)
  * has read rights when user is viewer for the category or user is inspector or user is admin
  * no special handling for new requests, can always be changed!

- [x] `query { users(isRequester: Boolean) }`