### PR TITLE
🐞 budget_period { total_price_cents_requested_quantities … }

### DIFF
--- a/client/src/components/decorators.js
+++ b/client/src/components/decorators.js
@@ -91,11 +91,14 @@ export const RequestTotalAmount = fields => {
 
 // TODO: currency config, hardcoded to CH-de for now
 // NOTE: `precision: 0` because Procure only supports integers
-export const formatCurrency = (n = 0) =>
-  formatMoney(n / 100, {
+export const formatCurrency = (n = 0) => {
+  const amount = n / 100
+  if (!f.isNumber(amount) || f.isNaN(amount)) return '---'
+  return formatMoney(amount, {
     decimal: '.',
     thousand: "'",
     symbol: 'CHF',
     format: '%v %s',
     precision: 0
   })
+}

--- a/client/src/pages/admin/AdminBudgetPeriodsPage.js
+++ b/client/src/pages/admin/AdminBudgetPeriodsPage.js
@@ -38,6 +38,7 @@ const ADMIN_BUDGET_PERIODS_FRAGMENTS = {
       inspection_start_date
       end_date
       can_delete
+      # FIXME: is missing from schema!
       total_price_cents_requested_quantities
       total_price_cents_approved_quantities
     }

--- a/client/src/pages/admin/AdminBudgetPeriodsPage.js
+++ b/client/src/pages/admin/AdminBudgetPeriodsPage.js
@@ -38,7 +38,6 @@ const ADMIN_BUDGET_PERIODS_FRAGMENTS = {
       inspection_start_date
       end_date
       can_delete
-      # FIXME: is missing from schema!
       total_price_cents_requested_quantities
       total_price_cents_approved_quantities
     }
@@ -152,99 +151,110 @@ const BudgetPeriodsTable = ({ budgetPeriods, updateAction }) => {
                 </tr>
               </thead>
               <tbody>
-                {fields.map(({ toDelete = false, ...bp }, n) => (
-                  <tr
-                    key={n}
-                    className={cx([
-                      'rounded',
-                      {
-                        'text-strike bg-danger-light': toDelete,
-                        // new lines are marked and should show form validation styles
-                        'was-validated bg-info-light': !bp.id
-                      }
-                    ])}
-                  >
-                    <td>
-                      <FormField
-                        required
-                        label="Name"
-                        placeholder="Name"
-                        hideLabel
-                        readOnly={toDelete}
-                        {...formPropsFor(`${n}.name`)}
-                      />
-                    </td>
-                    <td>
-                      <FormGroup label="Startdatum der Prüfphase" hideLabel>
-                        <InputDate
+                {fields.map(({ toDelete = false, ...bp }, n) => {
+                  // FIXME: use bp.can_delete when fixed in API
+                  const canDelete = !(
+                    bp.total_price_cents_requested_quantities > 0 ||
+                    bp.total_price_cents_approved_quantities > 0
+                  )
+                  return (
+                    <tr
+                      key={n}
+                      className={cx([
+                        'rounded',
+                        {
+                          'text-strike bg-danger-light': toDelete,
+                          // new lines are marked and should show form validation styles
+                          'was-validated bg-info-light': !bp.id
+                        }
+                      ])}
+                    >
+                      <td>
+                        <FormField
                           required
+                          label="Name"
+                          placeholder="Name"
+                          hideLabel
                           readOnly={toDelete}
-                          inputProps={{
-                            className: cx({ 'text-strike ': toDelete })
-                          }}
-                          {...formPropsFor(`${n}.inspection_start_date`)}
+                          {...formPropsFor(`${n}.name`)}
                         />
-                      </FormGroup>
-                    </td>
-                    <td>
-                      <FormGroup label="Enddatum" hideLabel>
-                        <InputDate
-                          required
-                          readOnly={toDelete}
-                          inputProps={{
-                            className: cx({ 'text-strike ': toDelete })
-                          }}
-                          {...formPropsFor(`${n}.end_date`)}
-                        />
-                      </FormGroup>
-                    </td>
-                    <td>
-                      {bp.total_price_cents_requested_quantities > 0 &&
-                      bp.total_price_cents_approved_quantities > 0 ? (
-                        <React.Fragment>
-                          <Tooltipped
-                            text={'Total aller Anträge mit Status "Neu"'}
-                          >
-                            <Badge info id={`badge_requested_${n}`}>
-                              <Icon.ShoppingCart />{' '}
-                              <samp>
-                                {formatCurrency(
-                                  bp.total_price_cents_requested_quantities
-                                )}
-                              </samp>
-                            </Badge>
-                          </Tooltipped>{' '}
-                          <Tooltipped text={'Total aller bewilligten Anträge'}>
-                            <Badge success id={`badge_approved_${n}`}>
-                              <Icon.ShoppingCart />{' '}
-                              <samp>
-                                {formatCurrency(
-                                  bp.total_price_cents_approved_quantities
-                                )}
-                              </samp>
-                            </Badge>
-                          </Tooltipped>
-                        </React.Fragment>
-                      ) : (
-                        <FormGroup>
-                          <div className="form-check mt-2">
-                            <label className="form-check-label">
-                              <input
-                                className="form-check-input"
-                                type="checkbox"
-                                checked={toDelete}
-                                onChange={e => {
-                                  setValue(`${n}.toDelete`, !!e.target.checked)
-                                }}
-                              />
-                              {'remove'}
-                            </label>
-                          </div>
+                      </td>
+                      <td>
+                        <FormGroup label="Startdatum der Prüfphase" hideLabel>
+                          <InputDate
+                            required
+                            readOnly={toDelete}
+                            inputProps={{
+                              className: cx({ 'text-strike ': toDelete })
+                            }}
+                            {...formPropsFor(`${n}.inspection_start_date`)}
+                          />
                         </FormGroup>
-                      )}
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td>
+                        <FormGroup label="Enddatum" hideLabel>
+                          <InputDate
+                            required
+                            readOnly={toDelete}
+                            inputProps={{
+                              className: cx({ 'text-strike ': toDelete })
+                            }}
+                            {...formPropsFor(`${n}.end_date`)}
+                          />
+                        </FormGroup>
+                      </td>
+                      <td>
+                        {!canDelete ? (
+                          <React.Fragment>
+                            <Tooltipped
+                              text={'Total aller Anträge mit Status "Neu"'}
+                            >
+                              <Badge info id={`badge_requested_${n}`}>
+                                <Icon.ShoppingCart />{' '}
+                                <samp>
+                                  {formatCurrency(
+                                    bp.total_price_cents_requested_quantities
+                                  )}
+                                </samp>
+                              </Badge>
+                            </Tooltipped>{' '}
+                            <Tooltipped
+                              text={'Total aller bewilligten Anträge'}
+                            >
+                              <Badge success id={`badge_approved_${n}`}>
+                                <Icon.ShoppingCart />{' '}
+                                <samp>
+                                  {formatCurrency(
+                                    bp.total_price_cents_approved_quantities
+                                  )}
+                                </samp>
+                              </Badge>
+                            </Tooltipped>
+                          </React.Fragment>
+                        ) : (
+                          <FormGroup>
+                            <div className="form-check mt-2">
+                              <label className="form-check-label">
+                                <input
+                                  className="form-check-input"
+                                  type="checkbox"
+                                  checked={toDelete}
+                                  onChange={e => {
+                                    setValue(
+                                      `${n}.toDelete`,
+                                      !!e.target.checked
+                                    )
+                                  }}
+                                />
+                                {'remove'}
+                              </label>
+                            </div>
+                          </FormGroup>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
               <tfoot>
                 <tr>

--- a/server/resources/all/schema.edn
+++ b/server/resources/all/schema.edn
@@ -161,7 +161,16 @@
                                               :type (list :MainCategory)},
                             :name {:type (non-null String)},
                             :total_price_cents {:resolve :total-price-cents,
-                                                :type (non-null Int)}}},
+                                                :type (non-null Int)},
+                            :total_price_cents_approved_quantities
+                              {:resolve :total-price-cents-approved-quantities,
+                               :type (non-null Int)},
+                            :total_price_cents_order_quantities
+                              {:resolve :total-price-cents-order-quantities,
+                               :type (non-null Int)},
+                            :total_price_cents_requested_quantities
+                              {:resolve :total-price-cents-requested-quantities,
+                               :type (non-null Int)}}},
     :Building {:fields {:code {:type String},
                         :id {:type (non-null ID)},
                         :name {:type (non-null String)},

--- a/server/resources/all/schema.edn
+++ b/server/resources/all/schema.edn
@@ -152,25 +152,24 @@
                            :id {:type (non-null ID)},
                            :main_category {:resolve :main-category,
                                            :type (non-null :MainCategory)}}},
-    :BudgetPeriod {:fields {:can_delete {:resolve :can-delete-budget-period?,
-                                         :type (non-null Boolean)},
-                            :end_date {:type (non-null String)},
-                            :id {:type (non-null ID)},
-                            :inspection_start_date {:type (non-null String)},
-                            :main_categories {:resolve :main-categories,
-                                              :type (list :MainCategory)},
-                            :name {:type (non-null String)},
-                            :total_price_cents {:resolve :total-price-cents,
-                                                :type (non-null Int)},
-                            :total_price_cents_approved_quantities
-                              {:resolve :total-price-cents-approved-quantities,
-                               :type (non-null Int)},
-                            :total_price_cents_order_quantities
-                              {:resolve :total-price-cents-order-quantities,
-                               :type (non-null Int)},
-                            :total_price_cents_requested_quantities
-                              {:resolve :total-price-cents-requested-quantities,
-                               :type (non-null Int)}}},
+    :BudgetPeriod
+      {:fields {:can_delete {:resolve :can-delete-budget-period?,
+                             :type (non-null Boolean)},
+                :end_date {:type (non-null String)},
+                :id {:type (non-null ID)},
+                :inspection_start_date {:type (non-null String)},
+                :main_categories {:resolve :main-categories,
+                                  :type (list :MainCategory)},
+                :name {:type (non-null String)},
+                :total_price_cents {:resolve :total-price-cents,
+                                    :type (non-null Int)},
+                :total_price_cents_approved_quantities
+                  {:resolve :total-price-cents-approved-quantities, :type Int},
+                :total_price_cents_order_quantities
+                  {:resolve :total-price-cents-order-quantities, :type Int},
+                :total_price_cents_requested_quantities
+                  {:resolve :total-price-cents-requested-quantities,
+                   :type Int}}},
     :Building {:fields {:code {:type String},
                         :id {:type (non-null ID)},
                         :name {:type (non-null String)},

--- a/server/spec/graphql/budget_periods_spec.rb
+++ b/server/spec/graphql/budget_periods_spec.rb
@@ -2,6 +2,32 @@ require 'spec_helper'
 require_relative 'graphql_helper'
 
 describe 'budget periods' do
+  context 'query' do
+    example 'authorizes total_price_cents_* query path' do
+      FactoryBot.create(:request)
+
+      user = FactoryBot.create(:user)
+      FactoryBot.create(:category_inspector, user_id: user.id)
+
+      [:requested, :approved, :order].each do |qty_type|
+        tp = "total_price_cents_#{qty_type}_quantities"
+
+        q = <<-GRAPHQL
+          query {
+            budget_periods {
+              id
+              #{tp}
+            }
+          }
+        GRAPHQL
+
+        result = query(q, user.id)
+        expect(result['data']['budget_periods'].first[tp]).to be_nil
+        expect(result['errors'].first['exception']).to be == 'UnauthorizedException'
+      end
+    end
+  end
+
   context 'mutation' do
     before :example do
       budget_periods_before = [{ name: 'bp_to_delete' },

--- a/server/src/all/leihs/procurement/graphql/queries.clj
+++ b/server/src/all/leihs/procurement/graphql/queries.clj
@@ -46,7 +46,8 @@
    :current-user current-user/get-current-user,
    :department organization/get-department,
    :general-ledger-account request/general-ledger-account,
-   :inspectors inspectors/get-inspectors,
+   :inspectors (-> inspectors/get-inspectors
+                   (authorization/wrap-ensure-one-of [user-perms/admin?])),
    :main-category main-category/get-main-category,
    :main-categories main-categories/get-main-categories,
    :model model/get-model,

--- a/server/src/all/leihs/procurement/graphql/queries.clj
+++ b/server/src/all/leihs/procurement/graphql/queries.clj
@@ -91,6 +91,12 @@
    :template template/get-template,
    :templates templates/get-templates,
    :total-price-cents requests/total-price-cents,
+   :total-price-cents-requested-quantities
+     requests/total-price-cents-requested-quantities,
+   :total-price-cents-approved-quantities
+     requests/total-price-cents-approved-quantities,
+   :total-price-cents-order-quantities
+     requests/total-price-cents-order-quantities,
    :user user/get-user,
    :users users/get-users,
    :viewers (fn [context args value]

--- a/server/src/all/leihs/procurement/graphql/queries.clj
+++ b/server/src/all/leihs/procurement/graphql/queries.clj
@@ -92,11 +92,14 @@
    :templates templates/get-templates,
    :total-price-cents requests/total-price-cents,
    :total-price-cents-requested-quantities
-     requests/total-price-cents-requested-quantities,
+     (-> requests/total-price-cents-requested-quantities
+         (authorization/wrap-ensure-one-of [user-perms/admin?])),
    :total-price-cents-approved-quantities
-     requests/total-price-cents-approved-quantities,
+     (-> requests/total-price-cents-approved-quantities
+         (authorization/wrap-ensure-one-of [user-perms/admin?])),
    :total-price-cents-order-quantities
-     requests/total-price-cents-order-quantities,
+     (-> requests/total-price-cents-order-quantities
+         (authorization/wrap-ensure-one-of [user-perms/admin?])),
    :user user/get-user,
    :users users/get-users,
    :viewers (fn [context args value]

--- a/server/src/all/leihs/procurement/graphql/resolver.clj
+++ b/server/src/all/leihs/procurement/graphql/resolver.clj
@@ -18,7 +18,7 @@
                        .getSimpleName)]
              (log/warn m)
              (if (env/env #{:dev :test}) (log/debug e))
-             (graphql-resolve/resolve-as value {:message m, :exception n}))))))
+             (graphql-resolve/resolve-as nil {:message m, :exception n}))))))
 
 (defn- wrap-map-with-error
   [arg]


### PR DESCRIPTION
see <http://localhost:4000/admin/budget-periods>

maybe it got removed by accident when adding the other total_price stuff?

optional: Also, some GraphQL Errors (like this one) only show up as "Unclassified Error". Dont know why, haven't seen a pattern yet.

- [x] re-add fields (and/or rename in frontend if neccesary)
- [x] authorize query path, only admin can see those sums (for all requests) -> is already scoped!
- [x] authorize query path, only admin can see inspectors/requesters