### PR TITLE
handle schema parsing errors correctly

### DIFF
--- a/client/src/pages/admin/AdminCategoriesPage.js
+++ b/client/src/pages/admin/AdminCategoriesPage.js
@@ -65,6 +65,9 @@ const CATEGORIES_QUERY = gql`
           firstname
           lastname
         }
+        viewers {
+          id
+        }
       }
     }
   }

--- a/server/src/all/leihs/procurement/authorization.clj
+++ b/server/src/all/leihs/procurement/authorization.clj
@@ -1,7 +1,7 @@
 (ns leihs.procurement.authorization
   (:require [leihs.procurement.env :as env]
             [leihs.procurement.permissions.user :as user-perms]
-            [leihs.procurement.utils.helpers :as helpers])
+            [leihs.procurement.graphql.helpers :as helpers])
   (:import leihs.procurement.UnauthorizedException))
 
 (defn wrap-ensure-one-of

--- a/server/src/all/leihs/procurement/graphql.clj
+++ b/server/src/all/leihs/procurement/graphql.clj
@@ -45,8 +45,11 @@
   (try (graphql-parser/parse-query (get-schema) query)
        (catch Throwable e*
          (let [e (get-cause e*)
-               m (.getMessage e*)]
-           (log/warn m)
+               m (.getMessage e*)
+               n (-> e*
+                     .getClass
+                     .getSimpleName)]
+           (log/warn (or m n))
            (if (env/env #{:dev :test}) (log/debug e))
            (helpers/error-as-graphql-object "API_ERROR" m)))))
 

--- a/server/src/all/leihs/procurement/graphql/helpers.clj
+++ b/server/src/all/leihs/procurement/graphql/helpers.clj
@@ -42,7 +42,7 @@
 
 (defn error-as-graphql-object
   [code message]
-  {:errors [{:message message,
+  {:errors [{:message (str message), ; if message is nil convert to ""
              :extensions {:code code,
                           :timestamp (-> (clj-time/now)
                                          .toString)}}],

--- a/server/src/all/leihs/procurement/graphql/helpers.clj
+++ b/server/src/all/leihs/procurement/graphql/helpers.clj
@@ -1,5 +1,8 @@
 (ns leihs.procurement.graphql.helpers
-  (:require [com.walmartlabs.lacinia [executor :as executor]]))
+  (:require [cheshire.core :refer [generate-string] :rename
+             {generate-string to-json}]
+            [clj-time.core :as clj-time]
+            [com.walmartlabs.lacinia [executor :as executor]]))
 
 (defn add-resource-type [m t] (assoc m :resource-type t))
 
@@ -36,3 +39,15 @@
   [context]
   (or (:requests-args context)
       (get-requests-args-from-selections-tree context)))
+
+(defn error-as-graphql-object
+  [code message]
+  {:errors [{:message message,
+             :extensions {:code code,
+                          :timestamp (-> (clj-time/now)
+                                         .toString)}}],
+   :data []})
+
+(defn error-as-graphql
+  [code message]
+  (to-json (error-as-graphql-object code message)))

--- a/server/src/all/leihs/procurement/graphql/resolver.clj
+++ b/server/src/all/leihs/procurement/graphql/resolver.clj
@@ -10,17 +10,17 @@
   [resolver]
   (fn [context args value]
     (try (resolver context args value)
-         (catch Throwable _e
-           (let [e (get-cause _e)
+         (catch Throwable e*
+           (let [e (get-cause e*)
                  m (.getMessage e)
-                 n (-> _e
+                 n (-> e*
                        .getClass
                        .getSimpleName)]
-             (log/warn m)
+             (log/warn (or m n))
              (if (env/env #{:dev :test}) (log/debug e))
              (graphql-resolve/resolve-as nil
                                          {:message (str m), ; if message nil
-                                                            ; convert to ""
+                                          ; convert to ""
                                           :exception n}))))))
 
 (defn- wrap-map-with-error

--- a/server/src/all/leihs/procurement/graphql/resolver.clj
+++ b/server/src/all/leihs/procurement/graphql/resolver.clj
@@ -18,7 +18,10 @@
                        .getSimpleName)]
              (log/warn m)
              (if (env/env #{:dev :test}) (log/debug e))
-             (graphql-resolve/resolve-as nil {:message m, :exception n}))))))
+             (graphql-resolve/resolve-as nil
+                                         {:message (str m), ; if message nil
+                                                            ; convert to ""
+                                          :exception n}))))))
 
 (defn- wrap-map-with-error
   [arg]

--- a/server/src/all/leihs/procurement/utils/helpers.clj
+++ b/server/src/all/leihs/procurement/utils/helpers.clj
@@ -1,19 +1,4 @@
 (ns leihs.procurement.utils.helpers
-  (:require [cheshire.core :refer [generate-string] :rename
-             {generate-string to-json}]
-            [clj-time.core :as clj-time]
-            [clojure.set :refer [subset?]]))
+  (:require [clojure.set :refer [subset?]]))
 
 (defn submap? [m1 m2] (subset? (set m1) (set m2)))
-
-(defn error-as-graphql-object
-  [code message]
-  {:errors [{:message message,
-             :extensions {:code code,
-                          :timestamp (-> (clj-time/now)
-                                         .toString)}}],
-   :data []})
-
-(defn error-as-graphql
-  [code message]
-  (to-json (error-as-graphql-object code message)))

--- a/server/src/all/leihs/procurement/utils/ring_exception.clj
+++ b/server/src/all/leihs/procurement/utils/ring_exception.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [str keyword])
   (:require [clojure.tools.logging :as logging]
             [leihs.procurement.env :as env]
-            [leihs.procurement.utils.helpers :as helpers]
+            [leihs.procurement.graphql.helpers :as helpers]
             [logbug.thrown :as thrown]))
 
 (defn get-cause


### PR DESCRIPTION
@eins78 `query-path` in the error object will be renamed to `path` in the next lacinia version `0.29.0` (https://github.com/walmartlabs/lacinia/releases).