### PR TITLE
feat: add container build

### DIFF
--- a/bin/build-container
+++ b/bin/build-container
@@ -21,8 +21,8 @@ cd "${PROJECT_DIR}"
 ### functions #################################################################
 
 function build_core {
-  ./client/bin/build
-  ./server/bin/clj-uberjar
+  ./client/bin/build $PROJECT_DIR 
+  ./server/bin/clj-uberjar $PROJECT_DIR
 }
 
 ### MAIN ######################################################################

--- a/bin/env/asdf-helper.bash
+++ b/bin/env/asdf-helper.bash
@@ -1,0 +1,48 @@
+function asdf-load() {
+  if type "asdf" > /dev/null; then
+    echo "asdf OK"
+  else
+    echo "sourcing asdf from ~/.asdf/asdf.sh since it seems not present"
+    source ~/.asdf/asdf.sh
+  fi
+}
+
+function asdf-update-plugin-base(){
+  echo "INFO updateting asdf plugin ${ASDF_PLUGIN} for ${PROJECT_NAME}"
+  asdf-load
+  if $(asdf plugin list | grep -q $ASDF_PLUGIN); then
+    echo "asdf $ASDF_PLUGIN found: updating "
+    asdf plugin update $ASDF_PLUGIN
+  else
+    echo "asdf $ASDF_PLUGIN NOT found: installing "
+    asdf plugin add $ASDF_PLUGIN ${ASDF_PLUGIN_URL}
+  fi
+  cd $PROJECT_DIR
+  asdf install $ASDF_PLUGIN
+}
+
+function asdf-update-plugin () {
+  asdf-load
+  TMPDIR=${TMPDIR:-/tmp/}
+  PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd ../.. > /dev/null 2>&1 && pwd -P)"
+  # in deployed states we are not in a git repo; however asdf und plugins should be set up already
+  if ! git -C $PROJECT_DIR rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "WARNING ${PROJECT_DIR} is not a git repository, SKIPPING asdf plugin and install update"
+  else
+    if [[ $(git -C $PROJECT_DIR status -s) ]]; then
+      echo "WARNING ${PROJECT_DIR} has uncommitted changes, forcing asdf plugin and install update"
+      asdf-update-plugin-base
+    else
+      DIGEST=$(git log -1 HEAD --pretty=format:%T)
+      CACHE_FILE="${TMPDIR}asdf_cache_${PROJECT_NAME}_${ASDF_PLUGIN}_${DIGEST}"
+      if [[ -f $CACHE_FILE ]]; then
+        echo "INFO $CACHE_FILE exists; skipping ${PROJECT_NAME} asdf update"
+      else
+        asdf-update-plugin-base
+        touch $CACHE_FILE
+      fi
+    fi
+  fi
+}
+
+# vim: set ft=sh

--- a/bin/env/clojure-setup
+++ b/bin/env/clojure-setup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd ../.. > /dev/null 2>&1 && pwd -P)"
+PROJECT_NAME=leihs-procure-server
+ASDF_PLUGIN=clojure
+ASDF_PLUGIN_URL=https://github.com/asdf-community/asdf-clojure.git
+
+source $PROJECT_DIR/bin/env/asdf-helper.bash
+asdf-update-plugin
+
+# vi: ft=sh

--- a/bin/env/java-setup
+++ b/bin/env/java-setup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd ../.. > /dev/null 2>&1 && pwd -P)"
+PROJECT_NAME=leihs-procure-server
+ASDF_PLUGIN=java
+ASDF_PLUGIN_URL=https://github.com/halcyon/asdf-java.git
+
+source $PROJECT_DIR/bin/env/asdf-helper.bash
+asdf-update-plugin
+
+# vi: ft=sh

--- a/bin/env/nodejs-setup
+++ b/bin/env/nodejs-setup
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -x
+
+echo "Setting up nodejs"
 
 PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd ../.. > /dev/null 2>&1 && pwd -P)"
 PROJECT_NAME=leihs-procure
 ASDF_PLUGIN=nodejs
 ASDF_PLUGIN_URL=https://github.com/asdf-vm/asdf-nodejs.git
 
-source $PROJECT_DIR/server/shared-clj/bin/env/asdf-helper.bash
+source ${PROJECT_DIR}/bin/env/asdf-helper.bash
 asdf-update-plugin
 
 # vi: ft=sh

--- a/bin/set-built-info.rb
+++ b/bin/set-built-info.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+# NOTE: if git info already given via env vars, dont use git at all!
+commit_id = ENV['BUILD_COMMIT_ID']
+tree_id = ENV['BUILD_TREE_ID']
+
+require 'bundler/inline'
+gemfile do
+  source 'https://rubygems.org'
+  gem 'git', '= 2.1.1', require: false
+  gem 'pry', '= 0.14.1'
+  gem 'activesupport', '= 5.2.4.5'
+end
+
+require 'active_support/all'
+require 'date'
+require 'pathname'
+require 'pry'
+require 'socket'
+require 'yaml'
+
+__file__ = __FILE__
+script = Pathname(__file__)
+
+PROJECT_DIR = Pathname(File.expand_path(File.dirname(__FILE__))).join('..')
+
+unless commit_id.present? && tree_id.present?
+  require 'git'
+  project = Git.open(PROJECT_DIR)
+  commit_id = project.log[0].sha
+  head = project.object('HEAD')
+  tree_id = head.gtree.objectish
+end
+
+IO.write(PROJECT_DIR.join("resources").join("built-info.yml"),
+         {commit_id: commit_id,
+          hostname: Socket.gethostname,
+          os: Gem::Platform.local.to_s,
+          timestamp: DateTime.now.iso8601,
+          tree_id: tree_id, }.with_indifferent_access.to_h.to_yaml)

--- a/cider-ci.yml
+++ b/cider-ci.yml
@@ -1,3 +1,6 @@
+include: container-build/cider-ci.yml
+
+
 jobs:
   procure-uberjar-build:
     include: cider-ci/jobs/uberjar.yml

--- a/client/bin/build
+++ b/client/bin/build
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd .. > /dev/null 2>&1 && pwd -P)"
-cd $PROJECT_DIR
-echo $PROJECT_DIR
+if [[ $@ ]]; then
+  echo "Using project directory $@"
+  PROJECT_DIR=$@
+  CLIENT_DIR=$@/client
+else
+  echo "Using project directory from script"
+  PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd .. > /dev/null 2>&1 && pwd -P)"
+  CLIENT_DIR=$PROJECT_DIR
+fi
 
-$PROJECT_DIR/bin/env/nodejs-setup
+${PROJECT_DIR}/bin/env/nodejs-setup
+
+cd $CLIENT_DIR
 
 npm ci --no-audit
 npm run build

--- a/container-build/bin/asdf-install
+++ b/container-build/bin/asdf-install
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+apt update --yes
+apt dist-upgrade --yes
+
+apt install --yes \
+  git \
+  curl
+
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.14.0
+
+echo '. "$HOME/.asdf/asdf.sh"' >> ~/.bashrc
+echo '. "$HOME/.asdf/completions/asdf.bash"' >> ~/.bashrc
+
+cat ~/.bashrc
+
+# vi set ft=sh

--- a/container-build/bin/prepare
+++ b/container-build/bin/prepare
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+apt update --yes
+apt dist-upgrade --yes
+
+apt install --yes \
+  build-essential \
+  bzip2 \
+  git \
+  libffi-dev \
+  libncurses5-dev \
+  libncursesw5-dev  \
+  libpq-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  python3-dev \
+  ruby-dev \
+  shared-mime-info \
+  zlib1g-dev
+
+
+# these did not work, why?
+#apt install --yes \
+#  locales-all \
+#  python3-pip
+#
+
+# vi set ft=sh

--- a/container-build/cider-ci.yml
+++ b/container-build/cider-ci.yml
@@ -1,0 +1,18 @@
+jobs:
+  container-build:
+    name: Build from scratch in clean container
+    run_when: &ON_BRANCH_UPDATE
+      any branch has been updated:
+        type: branch
+        include_match: ^.*$
+    context:
+      task_defaults:
+        environment_variables:
+          CI: "true"
+          LXC_BASE_IMAGE: "images:debian/bookworm/amd64"
+          LEIHS_PROCURE_DIR: "{{CIDER_CI_WORKING_DIR}}"
+          LEIHS_DATABASE_DIR: "{{LEIHS_ADMIN_DIR}}/server/database"
+          CONTAINER_NAME: "leihs-procure-build-{{CIDER_CI_TRIAL_ID}}"
+      tasks:
+        container-build:
+          include: container-build/task-components/container-build.yml

--- a/container-build/task-components/container-build.yml
+++ b/container-build/task-components/container-build.yml
@@ -1,0 +1,77 @@
+traits:
+  LXD: true
+
+git_options:
+  submodules:
+    include_match: ^.*$
+
+scripts:
+  container-create:
+    body: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      set -x
+
+      # start container
+
+      lxc image list
+      lxc launch --ephemeral ${LXC_BASE_IMAGE} ${CONTAINER_NAME}
+      lxc list
+
+      git repack -a
+      git submodule foreach --recursive 'git repack -a'
+
+      lxc file push --recursive ${CIDER_CI_WORKING_DIR} ${CONTAINER_NAME}/tmp/
+
+      lxc exec ${CONTAINER_NAME} -- mv /tmp/${CIDER_CI_TRIAL_ID} /leihs-procure
+      lxc exec ${CONTAINER_NAME} -- chown -R root:root /leihs-procure
+      lxc exec ${CONTAINER_NAME} -- touch /leihs-procure/test.txt
+      lxc exec ${CONTAINER_NAME} -- ls -l /leihs-procure
+      lxc exec ${CONTAINER_NAME} -- rm /leihs-procure/test.txt
+
+  container-prepare:
+    start_when:
+      container-create done:
+        script_key: container-create
+    body: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      set -x
+
+      lxc exec ${CONTAINER_NAME} -- /leihs-procure/container-build/bin/prepare
+      lxc exec ${CONTAINER_NAME} -- /leihs-procure/container-build/bin/asdf-install
+
+  container-build:
+    start_when:
+      container-prepare done:
+        script_key: container-prepare
+    timeout: 60 minutes
+    body: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      set -x
+
+      # odd
+      lxc exec ${CONTAINER_NAME} -- git config --global --add safe.directory /leihs-procure
+
+      lxc exec ${CONTAINER_NAME} -- /leihs-procure/bin/build-container
+
+  container-destroy:
+    start_when:
+      build done:
+        script_key: container-build
+        states: [aborted, passed, failed, skipped]
+    ignore_abort: yes
+    timeout: 1 Hour
+    body: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      set -x
+      lxc list
+      lxc info "$CONTAINER_NAME"
+
+      # enable for debugging; keeps the container running for a while
+      # sleep 1000
+
+      until lxc delete --force "$CONTAINER_NAME"; do sleep 10; done
+      lxc list

--- a/server/bin/clj-uberjar
+++ b/server/bin/clj-uberjar
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
-PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd .. > /dev/null 2>&1 && pwd -P)"
-cd $PROJECT_DIR
+
+if [[ $@ ]]; then
+  echo "Using project directory $@"
+  PROJECT_DIR=$@
+  SERVER_DIR=$@/server
+else
+  echo "Using project directory from script"
+  PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd .. > /dev/null 2>&1 && pwd -P)"
+  SERVER_DIR=$PROJECT_DIR
+fi
+
 $PROJECT_DIR/bin/env/java-setup
 $PROJECT_DIR/bin/env/clojure-setup
+
+cd $SERVER_DIR
+
 clojure -T:build uber
 
 # vi: ft=sh

--- a/server/bin/rspec
+++ b/server/bin/rspec
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
+# set -x
 PROJECT_DIR="$(cd -- "$(dirname "${BASH_SOURCE}")" ; cd .. > /dev/null 2>&1 && pwd -P)"
 cd $PROJECT_DIR
 ./bin/env/ruby-setup


### PR DESCRIPTION
I had to add command line args to the build scripts, since paths were not correctly resolved in the container due to the special folder structure in procure ( root level server and client ).
Also the build scripts had to be moved to the root bin dir.

Couldn't debug this in the container, hence the workaround.

Can potentially be solved differently.